### PR TITLE
scripts/meson.build: Use xxdi(.pl) instead of xxd

### DIFF
--- a/scripts/meson.build
+++ b/scripts/meson.build
@@ -1,5 +1,4 @@
 luac = find_program('luac')
-xxd = find_program('xxd')
 
 builtin_scripts = [
     'default.lua',
@@ -16,5 +15,5 @@ foreach s: builtin_scripts
     builtin_lua_scripts += custom_target('Converted ' + s + '.bin',
                                          input: compiled_script,
                                          output: s + '.bin' + '.h',
-                                         command: [xxd, '-i', '@INPUT@', '@OUTPUT@'])
+                                         command: [files('../tools/xxdi.py'), '@INPUT@', '@OUTPUT@'])
 endforeach

--- a/src/txproto_main.c
+++ b/src/txproto_main.c
@@ -2198,8 +2198,8 @@ int main(int argc, char *argv[])
     lua_setglobal(ctx->lua, LUA_PUB_PREFIX);
 
     /* Load Lua utilities */
-    err = luaL_loadbufferx(ctx->lua, scripts_utils_lua_bin,
-                           scripts_utils_lua_bin_len, "built-in utilities", "b");
+    err = luaL_loadbufferx(ctx->lua, utils_lua_bin, utils_lua_bin_len,
+                           "built-in utilities", "b");
     if (err) {
         sp_log(ctx, SP_LOG_ERROR, "%s\n", lua_tostring(ctx->lua, -1));
         err = AVERROR_EXTERNAL;
@@ -2217,8 +2217,8 @@ int main(int argc, char *argv[])
         if ((err = lfn_loadfile(ctx, script_name)))
             goto end;
     } else {
-        err = luaL_loadbufferx(ctx->lua, scripts_default_lua_bin,
-                               scripts_default_lua_bin_len, "built-in script", "b");
+        err = luaL_loadbufferx(ctx->lua, default_lua_bin, default_lua_bin_len,
+                               "built-in script", "b");
         if (err) {
             sp_log(ctx, SP_LOG_ERROR, "%s\n", lua_tostring(ctx->lua, -1));
             err = AVERROR_EXTERNAL;

--- a/tools/xxdi.py
+++ b/tools/xxdi.py
@@ -2,6 +2,7 @@
 # xxdi.py - Pure Python3 implementation of 'xxd -i [input] [output]'
 import sys
 from functools import partial
+from os.path import basename
 
 count = 0
 
@@ -14,7 +15,7 @@ if argc == 1:
     fd_out = sys.stdout
 elif argc == 2 or argc == 3:
     fd_in = open(sys.argv[1], "rb")
-    target_name = sys.argv[1].replace('/','_').replace('$','_').replace('.','_')
+    target_name = basename(sys.argv[1]).replace('/','_').replace('$','_').replace('.','_')
     if argc == 3:
         fd_out = open(sys.argv[2], "w+")
     else:

--- a/tools/xxdi.py
+++ b/tools/xxdi.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# xxdi.py - Pure Python3 implementation of 'xxd -i [input] [output]'
+import sys
+from functools import partial
+
+count = 0
+
+# Convert '/', '$' and '.' to '_',
+# or if this is stdin just use "stdin" as the name.
+argc = len(sys.argv)
+if argc == 1:
+    fd_in = sys.stdin.buffer
+    target_name = 'stdin'
+    fd_out = sys.stdout
+elif argc == 2 or argc == 3:
+    fd_in = open(sys.argv[1], "rb")
+    target_name = sys.argv[1].replace('/','_').replace('$','_').replace('.','_')
+    if argc == 3:
+        fd_out = open(sys.argv[2], "w+")
+    else:
+        fd_out = sys.stdout
+else:
+	print("Too many arguments!", file=sys.stderr)
+	print("Usage: xxdi.py [input] [output]", file=sys.stderr)
+	exit(1)
+
+print("#pragma once\n#include <stdint.h>", file=fd_out)
+print("static const uint8_t %s[] = {" % target_name, file=fd_out)
+
+for block in iter(partial(fd_in.read, 12), b''):
+    fd_out.write('\t')
+    for i in block:
+        print("0x%02x" % i, end=', ', file=fd_out)
+        count += 1;
+    fd_out.write('\n')
+
+print('};', file=fd_out)
+
+print('static const size_t %s_len = %d;' % (target_name, count), file=fd_out)
+
+fd_in.close()


### PR DESCRIPTION
This allows to only depend on a simple standalone script[1] rather than on vim,
using od(1) instead should be considered as it is into POSIX,
so present virtually everywhere.

(Couldn't build txproto further, probably related to libplacebo but it seems to be working fine)

1: https://github.com/gregkh/xxdi