### PR TITLE
Require libplacebo >=3.104.0, rename pl_render_target

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -44,7 +44,7 @@ dependencies = [
     dependency('libavutil', version: '>= 56.43.100'),
 
     # placebo
-    dependency('libplacebo', version: '>= 2.46.0'),
+    dependency('libplacebo', version: '>= 3.104.0'),
 
     # vulkan
     dependency('vulkan', version: '>= 1.1'),

--- a/src/interface_highlight.h
+++ b/src/interface_highlight.h
@@ -300,8 +300,8 @@ static int render_highlight(void *wctx)
     render_params.allow_delayed_peak_detect = 1;
 
     /* Set rendering target params */
-    struct pl_render_target target = { 0 };
-    pl_render_target_from_swapchain(&target, &frame);
+    struct pl_frame target = { 0 };
+    pl_frame_from_swapchain(&target, &frame);
     target.crop.x0 = x0;
     target.crop.x1 = x1;
     target.crop.y0 = y0;

--- a/src/interface_main.h
+++ b/src/interface_main.h
@@ -287,8 +287,8 @@ static int render_main(void *wctx)
     render_params.allow_delayed_peak_detect = 1;
 
     /* Set rendering target params */
-    struct pl_render_target target = { 0 };
-    pl_render_target_from_swapchain(&target, &frame);
+    struct pl_frame target = { 0 };
+    pl_frame_from_swapchain(&target, &frame);
     target.dst_rect.x0 = 0;
     target.dst_rect.y0 = 0;
     target.dst_rect.x1 = win->width;


### PR DESCRIPTION
There is places where pl_render_target.crop is used, this never really existed
as it's from when pl_render_target got renamed to pl_frame.[1]

3.104.0 is the earliest release with `pl_frame` being present.

(Tested the build with libplacebo-3.10.4 but txproto still segfaults on my machine)

1: https://code.videolan.org/videolan/libplacebo/-/commit/5b508c5b565f0317a366398cf2e178c0cf4ffdbd