### PR TITLE
Require libavcodec 59.4.100

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -39,7 +39,7 @@ build_opts = [
 threads_dep = dependency('threads')
 dependencies = [
     # ffmpeg libs
-    dependency('libavcodec', version: '>= 58.82.100'),
+    dependency('libavcodec', version: '>= 59.4.100'),
     dependency('libavformat', version: '>= 58.42.100'),
     dependency('libswresample', version: '>= 3.6.100'),
     dependency('libavfilter', version: '>= 7.79.100'),


### PR DESCRIPTION
AVPacket->{time_base,opaque} were implemented here:
https://github.com/FFmpeg/FFmpeg/commit/a1a0fddfd05c1dd0c03e5aa4d51baedad59fa117
