### PR TITLE
xcb: Avoid to pop the acquired screen from the entries

### DIFF
--- a/src/iosys_xcb.c
+++ b/src/iosys_xcb.c
@@ -669,7 +669,7 @@ static int xcb_ctrl(AVBufferRef *ctx_ref, SPEventType ctrl, void *arg)
 static AVBufferRef *xcb_ref_entry(AVBufferRef *ctx_ref, uint32_t identifier)
 {
     XCBCtx *ctx = (XCBCtx *)ctx_ref->data;
-    return sp_bufferlist_pop(ctx->entries, sp_bufferlist_iosysentry_by_id, &identifier);
+    return sp_bufferlist_ref(ctx->entries, sp_bufferlist_iosysentry_by_id, &identifier);
 }
 
 static void xcb_uninit(void *opaque, uint8_t *data)


### PR DESCRIPTION
This prevent the acquisition thread to detect a resolution change.

Because the entry is removed from the entry list, a new entry will be detected during the next call of iter_monitors(). This new entry will be used to detect the resolution change, but the acquisition thread won't be notified.