### PR TITLE
Fix build with interface enabled

### DIFF
--- a/src/lua_generic_api.c
+++ b/src/lua_generic_api.c
@@ -16,6 +16,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include "../config.h"
+
 #ifdef HAVE_INTERFACE
 #include "interface_common.h"
 #endif


### PR DESCRIPTION
This fixes a build regression introduced by 669f466b41f50be9846c30476756a687ed3b9133.

`config.h` was included by internal headers, but `interface_common.h` wasn't because it was under at the very top of the file, not included because of `#ifdef HAVE_INTERFACE`. The rest of the file had `HAVE_INTERFACE` defind an then the build failed.