### PR TITLE
logging/get_class: Remove unwanted assert

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -122,7 +122,9 @@ static inline SPClass *get_class(void *ctx)
         SPClass *class;
     } *s = ctx;
 
-    sp_assert(!!s->class);
+    if (!s->class)
+        return NULL;
+
     sp_assert(s->class->canary == CANARY_PATTERN);
 
     return s->class;


### PR DESCRIPTION
When using a X11 environment, wlcapture_init() call to sp_wayland_create() will fail before calling sp_class_alloc().

wlcapture_uninit() will call sp_class_free()/get_class() that requires sp_class_alloc() to have been called.

Remove the assert and let sp_class_free() to be called even if sp_class_alloc() hasn't been called.