### PR TITLE
Add an high-level C API

### DIFF
--- a/DOCS/examples/desktop_record.c
+++ b/DOCS/examples/desktop_record.c
@@ -1,0 +1,123 @@
+#include <stdio.h>
+#include <assert.h>
+#include <limits.h>
+#include <pthread.h>
+
+#include <libavutil/buffer.h>
+#include <libavutil/dict.h>
+#include <libavutil/time.h>
+
+#include <libtxproto/events.h>
+#include <libtxproto/txproto.h>
+
+// gcc -Wall -g desktop_record.c -o desktop_record `pkg-config --cflags --libs txproto libavutil`
+
+typedef struct IoEntryCb {
+    uint32_t identifier;
+} IoEntryCb;
+
+static int source_event_cb(IOSysEntry *entry, void *userdata)
+{
+    IoEntryCb *cb_data = userdata;
+
+    printf("%s\n", __func__);
+    printf("\tName: %s\n", sp_class_get_name(entry));
+    printf("\tType: %s\n", sp_iosys_entry_type_string(entry->type));
+    printf("\tIdentifier: 0x%X\n", entry->identifier);
+    printf("\tDefault: %d\n", entry->is_default);
+
+    if (sp_class_get_type(entry) & SP_TYPE_VIDEO_BIDIR) {
+        printf("\tX: %d\n", entry->x);
+        printf("\tY: %d\n", entry->y);
+        printf("\tWidth: %d\n", entry->width);
+        printf("\tHeight: %d\n", entry->height);
+        printf("\tScale: %d\n", entry->scale);
+        printf("\tFramerate: %f\n", av_q2d(entry->framerate));
+
+        if (!cb_data->identifier && entry->is_default)
+            cb_data->identifier = entry->identifier;
+    }
+
+    return 0;
+}
+
+int main(int argc, char *argv[])
+{
+    int err;
+
+    TXMainContext *ctx = tx_new();
+    err = tx_init(ctx);
+    assert(err == 0);
+
+    err = tx_epoch_set(ctx, 0);
+    assert(err == 0);
+
+    // Enumerate displays
+    IoEntryCb cb_data;
+    cb_data.identifier = 0;
+
+    AVBufferRef *event = tx_io_register_cb(
+        ctx,
+        NULL, // api_list
+        source_event_cb,
+        &cb_data
+    );
+    assert(event);
+
+    tx_event_destroy(ctx, event);
+
+    // Create encoding pipeline
+    AVBufferRef *video_source = tx_io_create(
+        ctx,
+        cb_data.identifier,
+        NULL // opts
+    );
+    assert(video_source);
+
+    // Encoder
+    AVDictionary *encoder_options = NULL;
+    err = av_dict_set(&encoder_options, "b", "20M", 0);
+    assert(err == 0);
+
+    err = av_dict_set(&encoder_options, "bf", "0", 0);
+    assert(err == 0);
+
+    AVBufferRef *encoder = tx_encoder_create(
+        ctx,
+        "h264_nvenc",
+        NULL, // name
+        &encoder_options,
+        NULL // init_opts
+    );
+
+    err = tx_link(ctx, video_source, encoder, 0);
+    assert(err == 0);
+
+    // Muxer
+    AVDictionary *muxer_options = NULL;
+    err = av_dict_set_int(&muxer_options, "low_latency", 1, 0);
+    assert(err == 0);
+
+    err = av_dict_set(&muxer_options, "sdp_file", "video.sdp", 0);
+    assert(err == 0);
+
+    AVBufferRef *muxer = tx_muxer_create(
+        ctx,
+        "rtp://127.0.0.1:30000",
+        "rtp",
+        muxer_options
+    );
+
+    err = tx_link(ctx, encoder, muxer, 0);
+    assert(err == 0);
+
+    // Commit
+    err = tx_commit(ctx);
+    assert(err == 0);
+
+    av_usleep(30000000);
+
+    tx_free(ctx);
+
+    return 0;
+}

--- a/DOCS/examples/transcode_video.c
+++ b/DOCS/examples/transcode_video.c
@@ -1,0 +1,143 @@
+#include <stdio.h>
+#include <assert.h>
+#include <limits.h>
+#include <pthread.h>
+
+#include <libavutil/buffer.h>
+#include <libavutil/dict.h>
+#include <libavutil/time.h>
+
+#include <libtxproto/events.h>
+#include <libtxproto/txproto.h>
+
+// gcc -Wall -g transcode_video.c -o transcode_video `pkg-config --cflags --libs txproto libavutil`
+
+struct EosEvent {
+    pthread_cond_t *cond;
+    int eos;
+};
+
+static int muxer_eos_cb(AVBufferRef *event_ref, void *callback_ctx, void *ctx,
+                 void *dep_ctx, void *data)
+{
+    struct EosEvent *event = callback_ctx;
+
+    printf("End of stream!\n");
+    event->eos = 1;
+
+    int err = pthread_cond_signal(event->cond);
+    assert(err == 0);
+
+    return 0;
+}
+
+int main(int argc, char *argv[])
+{
+    int err;
+
+    TXMainContext *ctx = tx_new();
+    err = tx_init(ctx);
+    assert(err == 0);
+
+    err = tx_epoch_set(ctx, 0);
+    assert(err == 0);
+
+    // Demuxer
+    AVBufferRef *demuxer = tx_demuxer_create(
+        ctx,
+        NULL, // Name
+        "test.webm", // in_url
+        NULL, // in_format
+        NULL, // start_options
+        NULL // init_opts
+    );
+
+    // Decoder
+    AVBufferRef *decoder = tx_decoder_create(
+        ctx,
+        "vp9", // dec_name
+        NULL // init_opts
+    );
+
+    err = tx_link(ctx, demuxer, decoder, 0);
+    assert(err == 0);
+
+    // Encoder
+    AVDictionary *encoder_options = NULL;
+    err = av_dict_set(&encoder_options, "b", "20M", 0);
+    assert(err == 0);
+
+    err = av_dict_set(&encoder_options, "bf", "0", 0);
+    assert(err == 0);
+
+    AVBufferRef *encoder = tx_encoder_create(
+        ctx,
+        "h264_nvenc",
+        NULL, // name
+        &encoder_options,
+        NULL // init_opts
+    );
+
+    err = tx_link(ctx, decoder, encoder, 0);
+    assert(err == 0);
+
+    // Muxer
+    AVBufferRef *muxer = tx_muxer_create(
+        ctx,
+        "out.mkv",
+        NULL, // out_format
+        NULL // init_opts
+    );
+
+    err = tx_link(ctx, encoder, muxer, 0);
+    assert(err == 0);
+
+    // Setup End of stream handler
+    pthread_mutex_t mtx;
+    err = pthread_mutex_init(&mtx, NULL);
+    assert(err == 0);
+
+    pthread_cond_t cond;
+    err = pthread_cond_init(&cond, NULL);
+    assert(err == 0);
+
+    AVBufferRef *muxer_eof_event = NULL;
+    muxer_eof_event = sp_event_create(muxer_eos_cb,
+                                     NULL,
+                                     sizeof(struct EosEvent),
+                                     NULL,
+                                     SP_EVENT_ON_EOS,
+                                     NULL,
+                                     NULL);
+
+    struct EosEvent *eos_event = av_buffer_get_opaque(muxer_eof_event);
+    eos_event->cond = &cond;
+    eos_event->eos = 0;
+
+    err = tx_event_register(ctx, muxer, muxer_eof_event);
+    assert(err == 0);
+
+    // Commit
+    err = tx_commit(ctx);
+    assert(err == 0);
+
+    // Wait for EOS
+    err = pthread_mutex_lock(&mtx);
+    assert(err == 0);
+
+    while (!eos_event->eos) {
+        err = pthread_cond_wait(&cond, &mtx);
+        assert(err == 0);
+    }
+
+    err = pthread_mutex_unlock(&mtx);
+    assert(err == 0);
+
+    // Free everything
+    av_buffer_unref(&muxer_eof_event);
+    pthread_mutex_destroy(&mtx);
+    pthread_cond_destroy(&cond);
+    tx_free(ctx);
+
+    return 0;
+}

--- a/DOCS/examples/transcode_video.lua
+++ b/DOCS/examples/transcode_video.lua
@@ -1,0 +1,34 @@
+function muxer_stats(stats)
+    statusline = "Encoding, bitrate: " .. math.floor(stats.bitrate / 1000) .. " Kbps"
+    tx.set_status(statusline)
+end
+
+function main(...)
+    tx.set_epoch(0)
+
+    source_f = tx.create_demuxer({
+        in_url = "test.webm",
+    })
+
+    dec_v = tx.create_decoder({
+        decoder = "vp9",
+    })
+    dec_v.link(source_f, 0);
+
+    encoder_v = tx.create_encoder({
+        encoder = "libx264",
+        options = {
+            b = "5M",
+        },
+    })
+    encoder_v.link(dec_v)
+
+    muxer_v = tx.create_muxer({
+        out_url = "test-transcoded.mkv",
+        priv_options = { dump_info = true, low_latency = false },
+    })
+    muxer_v.link(encoder_v)
+    muxer_v.schedule("stats", muxer_stats)
+
+    tx.commit()
+end

--- a/src/include/libtxproto/txproto.h
+++ b/src/include/libtxproto/txproto.h
@@ -1,0 +1,108 @@
+/*
+ * This file is part of txproto.
+ *
+ * txproto is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * txproto is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with txproto; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#pragma once
+
+#include <libavutil/buffer.h>
+#include <libavutil/dict.h>
+#include <libavutil/hwcontext.h>
+
+typedef struct TXMainContext TXMainContext;
+
+#include <libtxproto/io.h>
+
+TXMainContext *tx_new(void);
+
+int tx_init(TXMainContext *ctx);
+
+void tx_free(TXMainContext *ctx);
+
+int tx_epoch_set(TXMainContext *ctx, int64_t value);
+
+int tx_commit(TXMainContext *ctx);
+
+AVBufferRef *tx_demuxer_create(
+    TXMainContext *ctx,
+    const char *name,
+    const char *in_url,
+    const char *in_format,
+    AVDictionary *start_options,
+    AVDictionary *init_opts
+);
+
+AVBufferRef *tx_decoder_create(
+    TXMainContext *ctx,
+    const char *dec_name,
+    AVDictionary *init_opts
+);
+
+AVBufferRef *tx_encoder_create(
+    TXMainContext *ctx,
+    const char *enc_name,
+    const char *name,
+    AVDictionary **options,
+    AVDictionary *init_opts
+);
+
+AVBufferRef *tx_muxer_create(
+    TXMainContext *ctx,
+    const char *out_url,
+    const char *out_format,
+    AVDictionary *init_opts
+);
+
+AVBufferRef *tx_filtergraph_create(
+    TXMainContext *ctx,
+    const char *graph,
+    enum AVHWDeviceType hwctx_type,
+    AVDictionary *init_opts
+);
+
+int tx_link(
+    TXMainContext *ctx,
+    AVBufferRef *src,
+    AVBufferRef *dst,
+    int src_stream_id
+);
+
+int tx_destroy(
+    TXMainContext *ctx,
+    AVBufferRef **ref
+);
+
+int tx_event_register(
+    TXMainContext *ctx,
+    AVBufferRef *target,
+    AVBufferRef *event
+);
+
+int tx_event_destroy(
+    TXMainContext *ctx,
+    AVBufferRef *event
+);
+
+AVBufferRef *tx_io_register_cb(
+    TXMainContext *ctx,
+    const char **api_list,
+    int (*source_event_cb)(IOSysEntry *entry, void *userdata),
+    void *userdata
+);
+
+AVBufferRef *tx_io_create(TXMainContext *ctx,
+                          uint32_t identifier,
+                          AVDictionary *opts);

--- a/src/meson.build
+++ b/src/meson.build
@@ -36,6 +36,7 @@ sources = [
     'control.c',
     'link.c',
     'io.c',
+    'txproto.c',
 
     # Version
     vcs_tag(command: ['git', 'rev-parse', '--short', 'HEAD'],
@@ -62,6 +63,7 @@ headers = [
     'control.h',
     'link.h',
     'io.h',
+    'txproto.h',
 ]
 
 # libendit

--- a/src/txproto.c
+++ b/src/txproto.c
@@ -1,0 +1,395 @@
+#include <libavutil/buffer.h>
+#include <libavutil/opt.h>
+#include <libavutil/time.h>
+
+#include <libtxproto/control.h>
+#include <libtxproto/decode.h>
+#include <libtxproto/demux.h>
+#include <libtxproto/encode.h>
+#include <libtxproto/epoch.h>
+#include <libtxproto/filter.h>
+#include <libtxproto/link.h>
+#include <libtxproto/mux.h>
+#include <libtxproto/txproto_main.h>
+#include <libtxproto/txproto.h>
+
+TXMainContext *tx_new(void)
+{
+    TXMainContext *ctx = av_mallocz(sizeof(*ctx));
+    return ctx;
+}
+
+int tx_init(TXMainContext *ctx)
+{
+    int err;
+
+    if ((err = sp_log_init(SP_LOG_INFO)) < 0)
+        return err;
+
+    if ((err = sp_class_alloc(ctx, "tx", SP_TYPE_NONE, NULL)) < 0) {
+        sp_log_uninit();
+        av_free(ctx);
+        return err;
+    }
+
+    //sp_log_set_ctx_lvl_str("global", "trace");
+
+    /* Print timestamps in logs */
+    sp_log_print_ts(1);
+
+    ctx->events = sp_bufferlist_new();
+    ctx->ext_buf_refs = sp_bufferlist_new();
+    ctx->epoch_value = ATOMIC_VAR_INIT(0);
+    ctx->source_update_cb_ref = -2; /* R2 HACK */
+
+    return 0;
+}
+
+void tx_free(TXMainContext *ctx)
+{
+    if (!ctx)
+        return;
+
+    sp_log_set_status(NULL, SP_STATUS_LOCK | SP_STATUS_NO_CLEAR);
+
+    /* Discard queued events */
+    sp_eventlist_dispatch(ctx, ctx->events, SP_EVENT_ON_DISCARD, NULL);
+
+    /* Free lists that may carry contexts around */
+    sp_bufferlist_free(&ctx->events);
+
+    /* Free all contexts */
+    sp_bufferlist_free(&ctx->ext_buf_refs);
+
+    /* Stop logging */
+    sp_log_uninit();
+
+    /* Free any auxiliary data */
+    sp_class_free(ctx);
+    av_free(ctx);
+}
+
+int tx_epoch_set(TXMainContext *ctx, int64_t value)
+{
+    AVBufferRef *epoch_event = sp_epoch_event_new(ctx);
+
+    int err = sp_epoch_event_set_offset(epoch_event, value);
+    if (err < 0) {
+        sp_log(ctx, SP_LOG_ERROR, "Unable to set epoch offset: %s!", av_err2str(err));
+        goto err;
+    }
+
+    sp_log(ctx, SP_LOG_ERROR, "Unable to set epoch offset: %s!", av_err2str(err));
+    err = sp_eventlist_add(ctx, ctx->events, epoch_event, 0);
+    if (err < 0)
+        goto err;
+
+    return 0;
+
+err:
+    av_buffer_unref(&epoch_event);
+    return err;
+}
+
+int tx_commit(TXMainContext *ctx)
+{
+    sp_eventlist_dispatch(ctx, ctx->events, SP_EVENT_ON_COMMIT, NULL);
+
+    return 0;
+}
+
+AVBufferRef *tx_demuxer_create(
+    TXMainContext *ctx,
+    const char *name,
+    const char *in_url,
+    const char *in_format,
+    AVDictionary *start_options,
+    AVDictionary *init_opts
+) {
+    int err;
+    AVBufferRef *mctx_ref = sp_demuxer_alloc();
+    DemuxingContext *mctx = (DemuxingContext *)mctx_ref->data;
+
+    mctx->name = name;
+    mctx->in_url = in_url;
+    mctx->in_format = in_format;
+    mctx->start_options = start_options;
+
+    err = sp_demuxer_init(mctx_ref);
+    if (err < 0) {
+        sp_log(ctx, SP_LOG_ERROR, "Unable to init demuxer: %s!", av_err2str(err));
+        goto err;
+    }
+
+    if (init_opts) {
+        err = sp_demuxer_ctrl(mctx_ref, SP_EVENT_CTRL_OPTS | SP_EVENT_FLAG_IMMEDIATE, init_opts);
+        if (err < 0) {
+            sp_log(ctx, SP_LOG_ERROR, "Unable to set options: %s!", av_err2str(err));
+            goto err;
+        }
+    }
+
+    sp_bufferlist_append_noref(ctx->ext_buf_refs, mctx_ref);
+
+    return mctx_ref;
+
+err:
+    av_buffer_unref(&mctx_ref);
+    return NULL;
+}
+
+AVBufferRef *tx_decoder_create(
+    TXMainContext *ctx,
+    const char *dec_name,
+    AVDictionary *init_opts
+) {
+    int err;
+    AVBufferRef *dctx_ref = sp_decoder_alloc();
+    DecodingContext *dctx = (DecodingContext *)dctx_ref->data;
+
+    dctx->codec = avcodec_find_decoder_by_name(dec_name);
+    if (!dctx->codec) {
+        sp_log(ctx, SP_LOG_ERROR,"Decoder \"%s\" not found!", dec_name);
+        goto err;
+    }
+
+    err = sp_decoder_init(dctx_ref);
+    if (err < 0) {
+        sp_log(ctx, SP_LOG_ERROR, "Unable to init decoder: %s!", av_err2str(err));
+        goto err;
+    }
+
+    if (init_opts) {
+        err = sp_decoder_ctrl(dctx_ref, SP_EVENT_CTRL_OPTS | SP_EVENT_FLAG_IMMEDIATE, init_opts);
+        if (err < 0) {
+            sp_log(ctx, SP_LOG_ERROR, "Unable to set options: %s!", av_err2str(err));
+            goto err;
+        }
+    }
+
+    sp_bufferlist_append_noref(ctx->ext_buf_refs, dctx_ref);
+
+    return dctx_ref;
+
+err:
+    av_buffer_unref(&dctx_ref);
+    return NULL;
+}
+
+AVBufferRef *tx_encoder_create(
+    TXMainContext *ctx,
+    const char *enc_name,
+    const char *name,
+    AVDictionary **options,
+    AVDictionary *init_opts
+) {
+    int err;
+    AVBufferRef *ectx_ref = sp_encoder_alloc();
+    EncodingContext *ectx = (EncodingContext *)ectx_ref->data;
+
+    ectx->codec = avcodec_find_encoder_by_name(enc_name);
+    if (!ectx->codec) {
+        sp_log(ctx, SP_LOG_ERROR, "Encoder \"%s\" not found!", enc_name);
+        goto err;
+    }
+
+    ectx->name = name;
+
+    err = sp_encoder_init(ectx_ref);
+    if (err < 0) {
+        sp_log(ctx, SP_LOG_ERROR, "Unable to init encoder: %s!", av_err2str(err));
+        goto err;
+    }
+
+    err = av_opt_set_dict(ectx->avctx, options);
+    assert(err == 0);
+
+    if (init_opts) {
+        err = sp_encoder_ctrl(ectx_ref, SP_EVENT_CTRL_OPTS | SP_EVENT_FLAG_IMMEDIATE, init_opts);
+        if (err < 0) {
+            sp_log(ctx, SP_LOG_ERROR, "Unable to set options: %s!", av_err2str(err));
+            goto err;
+        }
+    }
+
+    sp_bufferlist_append_noref(ctx->ext_buf_refs, ectx_ref);
+
+    return ectx_ref;
+
+err:
+    av_buffer_unref(&ectx_ref);
+    return NULL;
+}
+
+AVBufferRef *tx_muxer_create(
+    TXMainContext *ctx,
+    const char *out_url,
+    const char *out_format,
+    AVDictionary *init_opts
+) {
+    int err;
+    AVBufferRef *mctx_ref = sp_muxer_alloc();
+    MuxingContext *mctx = (MuxingContext *)mctx_ref->data;
+
+    mctx->out_url = out_url;
+    mctx->out_format = out_format;
+
+    err = sp_muxer_init(mctx_ref);
+    if (err < 0) {
+        sp_log(ctx, SP_LOG_ERROR, "Unable to init muxer: %s!", av_err2str(err));
+        goto err;
+    }
+
+    if (init_opts) {
+        err = sp_muxer_ctrl(mctx_ref, SP_EVENT_CTRL_OPTS | SP_EVENT_FLAG_IMMEDIATE, init_opts);
+        if (err < 0) {
+            sp_log(ctx, SP_LOG_ERROR, "Unable to set options: %s!", av_err2str(err));
+            goto err;
+        }
+    }
+
+    sp_bufferlist_append_noref(ctx->ext_buf_refs, mctx_ref);
+
+    return mctx_ref;
+
+err:
+    av_buffer_unref(&mctx_ref);
+    return NULL;
+}
+
+AVBufferRef *tx_filtergraph_create(
+    TXMainContext *ctx,
+    const char *graph,
+    enum AVHWDeviceType hwctx_type,
+    AVDictionary *init_opts
+) {
+    int err;
+    AVBufferRef *fctx_ref = sp_filter_alloc();
+
+    const char *name = NULL;
+    AVDictionary *opts = NULL;
+    char **in_pads = NULL;
+    char **out_pads = NULL;
+
+    err = sp_init_filter_graph(fctx_ref, name, graph, in_pads, out_pads, opts, hwctx_type);
+    if (err < 0) {
+        sp_log(ctx, SP_LOG_ERROR, "Unable to init filter: %s!", av_err2str(err));
+        goto err;
+    }
+
+    if (init_opts) {
+        err = sp_filter_ctrl(fctx_ref, SP_EVENT_CTRL_OPTS | SP_EVENT_FLAG_IMMEDIATE, init_opts);
+        if (err < 0) {
+            sp_log(ctx, SP_LOG_ERROR, "Unable to set options: %s!\n", av_err2str(err));
+            goto err;
+        }
+    }
+    av_dict_free(&init_opts);
+
+    sp_bufferlist_append_noref(ctx->ext_buf_refs, fctx_ref);
+
+    return fctx_ref;
+
+err:
+    av_buffer_unref(&fctx_ref);
+    return NULL;
+}
+
+int tx_link(
+    TXMainContext *ctx,
+    AVBufferRef *src,
+    AVBufferRef *dst,
+    int src_stream_id
+) {
+    return sp_generic_link(
+        ctx,
+        src,
+        dst,
+        1, // autostart,
+        NULL, // src_pad_name,
+        NULL, // dst_pad_name,
+        src_stream_id,
+        NULL // src_stream_desc
+    );
+}
+
+int tx_destroy(
+    TXMainContext *ctx,
+    AVBufferRef **ref
+) {
+    (void)sp_bufferlist_pop(ctx->ext_buf_refs, sp_bufferlist_find_fn_data, ref);
+    av_buffer_unref(ref);
+    return 0;
+}
+
+int tx_event_register(
+    TXMainContext *ctx,
+    AVBufferRef *target,
+    AVBufferRef *event
+) {
+    ctrl_fn target_ctrl_fn = sp_get_ctrl_fn(target->data);
+    if (!target_ctrl_fn) {
+        sp_log(ctx, SP_LOG_ERROR, "Unsupported CTRL type: %s!",
+               sp_class_type_string(target->data));
+        return AVERROR(EINVAL);
+    }
+
+    return target_ctrl_fn(target, SP_EVENT_CTRL_NEW_EVENT, event);
+}
+
+typedef struct SourceEventCtx {
+    int (*cb)(IOSysEntry *entry, void *userdata);
+    void *userdata;
+} SourceEventCtx;
+
+static int source_event_cb(AVBufferRef *event, void *callback_ctx, void *ctx,
+                           void *dep_ctx, void *data)
+{
+    SourceEventCtx *source_cb_ctx = callback_ctx;
+    IOSysEntry *entry = dep_ctx;
+
+    return (*source_cb_ctx->cb)(entry, source_cb_ctx->userdata);
+}
+
+int tx_event_destroy(
+    TXMainContext *ctx,
+    AVBufferRef *event
+) {
+    (void)sp_bufferlist_pop(ctx->ext_buf_refs, sp_bufferlist_find_fn_data, event);
+    sp_event_unref_expire(&event);
+
+    return 0;
+}
+
+AVBufferRef *tx_io_register_cb(
+    TXMainContext *ctx,
+    const char **api_list,
+    int (*cb)(IOSysEntry *entry, void *userdata),
+    void *userdata
+) {
+    AVBufferRef *source_event;
+    source_event = sp_io_alloc(ctx, (const char **)api_list, source_event_cb,
+                               NULL, sizeof(SourceEventCtx));
+    if (!source_event)
+        return NULL;
+
+    SourceEventCtx *source_event_ctx = av_buffer_get_opaque(source_event);
+    source_event_ctx->cb = cb;
+    source_event_ctx->userdata = userdata;
+
+    int err = sp_io_init(ctx, source_event, (const char **)api_list);
+    if (err < 0) {
+        sp_log(ctx, SP_LOG_ERROR, "Unable to reference %s!", "function");
+        av_buffer_unref(&source_event);
+        return NULL;
+    }
+
+    return source_event;
+}
+
+AVBufferRef *tx_io_create(TXMainContext *ctx,
+                          uint32_t identifier,
+                          AVDictionary *opts)
+{
+    return sp_io_create(ctx, identifier, opts);
+}


### PR DESCRIPTION
## Context

a0c4601d957d41cb75ecb5b25eea6b43199b5ac0 has exposed the decoder/encoder/demuxer/muxer API, and #24 has exposed the epoch/control/link/io API.

At this point, it is possible to reimplement the lua samples of the `DOCS` folder, using C. However, it still requires some boilerplate.

## PR goal

The goal of this PR is to add an higher-level API that provides an API that is closer to the lua API.

Two examples have been added in `DOCS`
* `desktop_record.c`: Simple desktop recording, streaming to RTP
* `transcode_video.c`: Transcode a VP9/webm file to H264/mkv using nvenc to encode. This sample also uses EOS notifications to quit when transcoded is complete