### PR TITLE
encode: Fix crash on EOS + Fix EOS propagation

### DIFF
--- a/src/encode.c
+++ b/src/encode.c
@@ -682,7 +682,6 @@ static void *encoding_thread(void *arg)
                     ret = 0;
                     break;
                 } else {
-                    ret = 0;
                     pthread_mutex_unlock(&ctx->lock);
                     goto end;
                 }

--- a/src/encode.c
+++ b/src/encode.c
@@ -487,15 +487,14 @@ static int video_process_frame(EncodingContext *ctx, AVFrame **input)
 }
 
 static int attach_sidedata(EncodingContext *ctx,
-                           AVPacket *pkt,
-                           const FormatExtraData *fe)
+                           AVPacket *pkt)
 {
     int ret;
 
     /* Gather metadata */
     AVDictionary *dict = NULL;
 
-    av_dict_set_int(&dict, "rotation", fe->rotation, 0);
+    av_dict_set_int(&dict, "rotation", ctx->rotation, 0);
 
     /* Attach metadata */
     size_t packed_dict_size = 0;
@@ -690,7 +689,7 @@ static void *encoding_thread(void *arg)
             }
 
             if (ctx->attach_sidedata == 1) {
-                ret = attach_sidedata(ctx, out_pkt, fe);
+                ret = attach_sidedata(ctx, out_pkt);
                 if (ret < 0) {
                     pthread_mutex_unlock(&ctx->lock);
                     goto fail;


### PR DESCRIPTION
779932ecb6b73829e549580e795fa919ef6e76ec has introduced two issues on EOS
* NULL pointer dereference
* EOF propagation has been broken

Also, this PR simplifies the rotation injection in sidedata that was too complicated.