### PR TITLE
chore: ignore `.cache` and `compile_commands.json`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.cache/
 build/
+compile_commands.json
 *.o
 ./*.lua


### PR DESCRIPTION
This is used by some tools (e.g. `clangd` and `ccls`) to provide Language Server Protocol support.