### PR TITLE
lua: demuxer options

### DIFF
--- a/src/lua_api.c
+++ b/src/lua_api.c
@@ -581,6 +581,8 @@ static int lua_create_demuxer(lua_State *L)
     if (err < 0)
         LUA_ERROR("Unable to init demuxer: %s!", av_err2str(err));
 
+    GET_OPTS_CLASS(mctx->avf, "options");
+
     AVDictionary *init_opts = NULL;
     GET_OPTS_DICT(init_opts, "priv_options");
     if (init_opts) {


### PR DESCRIPTION
I think this was an oversight because this line is present in `lua_create_muxer`? The main reason why I added this was to be able to change the `protocol_whitelist` to allow reading from rtp streams