### PR TITLE
fix: `tx_destroy` invalid pointer type

### DIFF
--- a/src/txproto.c
+++ b/src/txproto.c
@@ -329,7 +329,7 @@ int tx_destroy(
     TXMainContext *ctx,
     AVBufferRef **ref
 ) {
-    (void)sp_bufferlist_pop(ctx->ext_buf_refs, sp_bufferlist_find_fn_data, ref);
+    (void)sp_bufferlist_pop(ctx->ext_buf_refs, sp_bufferlist_find_fn_data, *ref);
     av_buffer_unref(ref);
     return 0;
 }


### PR DESCRIPTION
The callback expects `AVBufferRef*` but has been given `AVBufferRef**` this whole time.