### PR TITLE
Rename tx_epoch_set() and reexport tx_epoch_set_system()

### DIFF
--- a/src/include/libtxproto/txproto.h
+++ b/src/include/libtxproto/txproto.h
@@ -42,6 +42,8 @@ void tx_set_log_cb(tx_log_cb log_cb, void *userdata);
 
 int tx_epoch_set_offset(TXMainContext *ctx, int64_t value);
 
+int tx_epoch_set_system(TXMainContext *ctx);
+
 int tx_commit(TXMainContext *ctx);
 
 int tx_ctrl(TXMainContext *ctx, AVBufferRef *ref, SPEventType flags, void *arg);

--- a/src/include/libtxproto/txproto.h
+++ b/src/include/libtxproto/txproto.h
@@ -40,7 +40,7 @@ int tx_log_set_ctx_lvl_str(const char *component, const char *lvl);
 
 void tx_set_log_cb(tx_log_cb log_cb, void *userdata);
 
-int tx_epoch_set(TXMainContext *ctx, int64_t value);
+int tx_epoch_set_offset(TXMainContext *ctx, int64_t value);
 
 int tx_commit(TXMainContext *ctx);
 

--- a/src/txproto.c
+++ b/src/txproto.c
@@ -88,7 +88,7 @@ int tx_log_set_ctx_lvl_str(const char *component, const char *lvl)
     return sp_log_set_ctx_lvl_str(component, lvl);
 }
 
-int tx_epoch_set(TXMainContext *ctx, int64_t value)
+int tx_epoch_set_offset(TXMainContext *ctx, int64_t value)
 {
     AVBufferRef *epoch_event = sp_epoch_event_new(ctx);
 

--- a/src/txproto.c
+++ b/src/txproto.c
@@ -109,6 +109,27 @@ err:
     return err;
 }
 
+int tx_epoch_set_system(TXMainContext *ctx)
+{
+    AVBufferRef *epoch_event = sp_epoch_event_new(ctx);
+
+    int err = sp_epoch_event_set_system(epoch_event);
+    if (err < 0) {
+        sp_log(ctx, SP_LOG_ERROR, "Unable to set epoch system: %s!", av_err2str(err));
+        goto err;
+    }
+
+    err = sp_eventlist_add(ctx, ctx->events, epoch_event, 0);
+    if (err < 0)
+        goto err;
+
+    return 0;
+
+err:
+    av_buffer_unref(&epoch_event);
+    return err;
+}
+
 int tx_commit(TXMainContext *ctx)
 {
     return sp_eventlist_dispatch(ctx, ctx->events, SP_EVENT_ON_COMMIT, NULL);


### PR DESCRIPTION
* The initial naming of `tx_epoch_set()` didn't reflect the underlying API
* Just expose system clock