### PR TITLE
log: Add a callback API

### DIFF
--- a/src/include/libtxproto/log.h
+++ b/src/include/libtxproto/log.h
@@ -115,6 +115,12 @@ void sp_log(void *ctx, enum SPLogLevel level, const char *fmt, ...) sp_printf_fo
 /* Set log file */
 int sp_log_set_file(const char *path);
 
+/* Callback log */
+typedef void (*sp_log_log_cb)(const char *component, int level, const char *fmt,
+                              va_list args, void *userdata);
+
+void sp_log_set_log_cb(sp_log_log_cb cb, void *userdata);
+
 /* Enable/disable timestamp/component printing */
 void sp_log_print_ts(int enable);
 

--- a/src/include/libtxproto/txproto.h
+++ b/src/include/libtxproto/txproto.h
@@ -32,6 +32,13 @@ int tx_init(TXMainContext *ctx);
 
 void tx_free(TXMainContext *ctx);
 
+typedef void (*tx_log_cb)(const char *component, int level, const char *fmt,
+                          va_list args, void *userdata);
+
+int tx_log_set_ctx_lvl_str(const char *component, const char *lvl);
+
+void tx_set_log_cb(tx_log_cb log_cb, void *userdata);
+
 int tx_epoch_set(TXMainContext *ctx, int64_t value);
 
 int tx_commit(TXMainContext *ctx);

--- a/src/txproto.c
+++ b/src/txproto.c
@@ -69,6 +69,16 @@ void tx_free(TXMainContext *ctx)
     av_free(ctx);
 }
 
+void tx_set_log_cb(tx_log_cb log_cb, void *userdata)
+{
+    sp_log_set_log_cb(log_cb, userdata);
+}
+
+int tx_log_set_ctx_lvl_str(const char *component, const char *lvl)
+{
+    return sp_log_set_ctx_lvl_str(component, lvl);
+}
+
 int tx_epoch_set(TXMainContext *ctx, int64_t value)
 {
     AVBufferRef *epoch_event = sp_epoch_event_new(ctx);


### PR DESCRIPTION
Allow to forward txproto logs to an external logger.