### PR TITLE
Restore ffmpeg 6.1 compat

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -43,7 +43,7 @@ dependencies = [
     dependency('libavformat', version: '>= 58.42.100'),
     dependency('libswresample', version: '>= 3.6.100'),
     dependency('libavfilter', version: '>= 7.79.100'),
-    dependency('libavutil', version: '>= 58.37.100'),
+    dependency('libavutil', version: '>= 56.43.100'),
 
     # lua
     dependency('lua', version: ['>= ' + lua_ver, '< ' + lua_ver_maj.to_string() + '.' + (lua_ver_min + 1).to_string()]),


### PR DESCRIPTION
`pulse.c` uses a ffmpeg 7.0 API. However, it is possible to have the same behavior with an API available on 6.1.